### PR TITLE
Add libxi-dev

### DIFF
--- a/dolphin-rpi.sh
+++ b/dolphin-rpi.sh
@@ -2,6 +2,6 @@ git clone https://github.com/dolphin-emu/dolphin --depth=1 --recurse-submodules
 cd dolphin
 mkdir -p build && cd build
 
-sudo apt install libevdev-dev libudev-dev qt6-base-dev qt6-svg-dev qt6-base-private-dev qt6-wayland ninja-build git build-essential cmake --no-install-recommends -y
+sudo apt install libxi-dev libevdev-dev libudev-dev qt6-base-dev qt6-svg-dev qt6-base-private-dev qt6-wayland ninja-build git build-essential cmake --no-install-recommends -y
 cmake -G "Ninja" -DCMAKE_EXE_LINKER_FLAGS="-latomic" ..
 cmake --build . --config Release


### PR DESCRIPTION
Fixes the following error:

```
CMake Deprecation Warning at CMakeLists.txt:7 (cmake_policy):
  The OLD behavior for policy CMP0080 will be removed from a future version
  of CMake.

  The cmake-policies(7) manual explains that the OLD behaviors of all
  policies are deprecated and that a policy should be set to OLD only under
  specific short-term circumstances.  Projects should be ported to the NEW
  behavior and not rely on setting a policy to OLD.


-- Using GCC 12.2.0
-- Detected architecture: aarch64
-- Xrandr not found
-- Checking for module 'xi>=1.5.0'
--   Package 'xi', required by 'virtual:world', not found
CMake Error at /usr/share/cmake-3.25/Modules/FindPkgConfig.cmake:607 (message):
  A required package was not found
Call Stack (most recent call first):
  /usr/share/cmake-3.25/Modules/FindPkgConfig.cmake:829 (_pkg_check_modules_internal)
  CMakeLists.txt:514 (pkg_check_modules)


-- Configuring incomplete, errors occurred!
See also "/home/avasam/Downloads/dolphin/build/CMakeFiles/CMakeOutput.log".
See also "/home/avasam/Downloads/dolphin/build/CMakeFiles/CMakeError.log".
ninja: error: loading 'build.ninja': No such file or directory
```